### PR TITLE
some updates for modern Alien::Base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ MYMETA.yml
 _alien/
 _build/
 _install/
+_share/
 blib/

--- a/Build.PL
+++ b/Build.PL
@@ -12,11 +12,11 @@ my $builder = Alien::Base::ModuleBuild->new(
   dist_abstract => 'Build and install libffcall',
   license => 'perl',
   configure_requires => {
-    'Alien::Base' => 0,
+    'Alien::Base' => 0.005,
   },
   requires => {
     'perl' => '5.8.1',
-    'Alien::Base' => 0,
+    'Alien::Base' => 0.005,
   },
   dist_author => 'David Mertens <dcmertens.perl@gmail.com>',
   alien_name => 'ffcall',
@@ -25,10 +25,13 @@ my $builder = Alien::Base::ModuleBuild->new(
     pattern  => qr/ffcall-([\d.]+)\.tar\.gz$/,
   },
   alien_build_commands => [
-    '%pconfigure --prefix=%s --enable-shared', 
+    '%c --prefix=%s --enable-shared', 
     'make',
-    'make install'
   ],
+  alien_install_commands => [
+    'make install',
+  ],
+  alien_isolate_dynamic => 1,
   alien_provides_libs => '-lavcall -lcallback',
   resources => {
     bugtracker  => {

--- a/lib/Alien/FFCall.pm
+++ b/lib/Alien/FFCall.pm
@@ -48,8 +48,6 @@ Your module (.pm) file should look like this:
  use strict;
  use warnings;
  
- use Alien::FFCall;
- 
  our $VERSION = '0.01';
  
  require XSLoader;


### PR DESCRIPTION
- %c is now preferred for autoconf over %pconfigure
  (requires 0.005)
- install during the install step isntead of build will prevent
  many of the cpan testers failures reported for this module
- isolate the dynamic libraries means that Alien::FFCall is no
  longer a run-time dependency (update documentation to reflect
  that as well)
- add _share to the .gitignore
