### PR TITLE
Use the system version of ffcall if available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ MYMETA.yml
 _alien/
 _build/
 _install/
+_share/
 blib/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _build/
 _install/
 _share/
 blib/
+*.bak

--- a/Build.PL
+++ b/Build.PL
@@ -5,10 +5,6 @@ use lib 'inc';
 use My::ModuleBuild;
 
 my $builder = My::ModuleBuild->new(
-  'meta-spec' => {
-    version => '2',
-    url     => 'http://search.cpan.org/perldoc?CPAN::Meta::Spec',
-  },
   module_name => 'Alien::FFCall',
   dist_abstract => 'Build and install libffcall',
   license => 'perl',
@@ -35,15 +31,21 @@ my $builder = My::ModuleBuild->new(
   ],
   alien_isolate_dynamic => 1,
   alien_provides_libs => '-lavcall -lcallback',
-  resources => {
-    bugtracker  => {
-      web    => 'http://github.com/run4flat/Alien-FFCall/issues',
-      mailto => 'dcmertens.perl@gmail.com',
+  meta_merge => {
+    'meta-spec' => {
+      version => '2',
+      url     => 'http://search.cpan.org/perldoc?CPAN::Meta::Spec',
     },
-    repository  => {
-      url  => 'git://github.com/run4flat/Alien-FFCall.git',
-      web  => 'http://github.com/run4flat/Alien-FFCall',
-      type => 'git',
+    resources => {
+      bugtracker  => {
+        web    => 'http://github.com/run4flat/Alien-FFCall/issues',
+        mailto => 'dcmertens.perl@gmail.com',
+      },
+      repository  => {
+        url  => 'git://github.com/run4flat/Alien-FFCall.git',
+        web  => 'http://github.com/run4flat/Alien-FFCall',
+        type => 'git',
+      },
     },
   },
 );

--- a/Build.PL
+++ b/Build.PL
@@ -12,11 +12,11 @@ my $builder = Alien::Base::ModuleBuild->new(
   dist_abstract => 'Build and install libffcall',
   license => 'perl',
   configure_requires => {
-    'Alien::Base' => 0,
+    'Alien::Base' => 0.005,
   },
   requires => {
     'perl' => '5.8.1',
-    'Alien::Base' => 0,
+    'Alien::Base' => 0.005,
   },
   dist_author => 'David Mertens <dcmertens.perl@gmail.com>',
   alien_name => 'ffcall',
@@ -25,10 +25,13 @@ my $builder = Alien::Base::ModuleBuild->new(
     pattern  => qr/ffcall-([\d.]+)\.tar\.gz$/,
   },
   alien_build_commands => [
-    '%pconfigure --prefix=%s --enable-shared', 
+    '%c --prefix=%s --enable-shared', 
     'make',
-    'make install'
   ],
+  alien_install_commands => [
+    'make install',
+  ],
+  alien_isolate_dynamic => 1,
   alien_provides_libs => '-lavcall -lcallback',
   resources => {
     bugtracker  => {

--- a/Build.PL
+++ b/Build.PL
@@ -1,9 +1,10 @@
 use strict;
 use warnings;
 
-use Alien::Base::ModuleBuild;
+use lib 'inc';
+use My::ModuleBuild;
 
-my $builder = Alien::Base::ModuleBuild->new(
+my $builder = My::ModuleBuild->new(
   'meta-spec' => {
     version => '2',
     url     => 'http://search.cpan.org/perldoc?CPAN::Meta::Spec',
@@ -12,11 +13,12 @@ my $builder = Alien::Base::ModuleBuild->new(
   dist_abstract => 'Build and install libffcall',
   license => 'perl',
   configure_requires => {
-    'Alien::Base' => 0.005,
+    'Alien::Base' => 0.021,
+    'parent'      => 0,
   },
   requires => {
     'perl' => '5.8.1',
-    'Alien::Base' => 0.005,
+    'Alien::Base' => 0.021,
   },
   dist_author => 'David Mertens <dcmertens.perl@gmail.com>',
   alien_name => 'ffcall',

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,9 +1,10 @@
-README
 Build.PL
-lib/Alien/FFCall.pm
-MANIFEST This list of files
 ffcall-1.10.tar.gz
-t/00-load.t
-
-META.yml
+inc/My/ModuleBuild.pm
+inc/My/test.c
+lib/Alien/FFCall.pm
+MANIFEST			This list of files
 META.json
+META.yml
+README
+t/00-load.t

--- a/inc/My/ModuleBuild.pm
+++ b/inc/My/ModuleBuild.pm
@@ -1,0 +1,43 @@
+package My::ModuleBuild;
+
+use strict;
+use warnings;
+use parent 'Alien::Base::ModuleBuild';
+use File::Spec;
+
+sub alien_check_installed_version {
+  my($self) = @_;
+
+  my $b = $self->cbuilder;
+  
+  my $obj = eval {
+    $b->compile(
+      source => File::Spec->catfile(qw( inc My test.c )),
+    );
+  };
+  
+  return unless defined $obj;
+  
+  $self->add_to_cleanup($obj);
+  
+  my($exe, @rest) = eval {
+    $b->link_executable(
+      objects => [$obj],
+    );
+  };
+  
+  unlink $obj;
+  
+  return unless defined $exe;
+  
+  $self->add_to_cleanup($exe, @rest);
+
+  if(`$exe` =~ /version=([0-9\.]+)/) {
+    my $version = $1;
+    unlink $exe, @rest;
+    return $version;
+  }  
+  return;
+}
+
+1;

--- a/inc/My/test.c
+++ b/inc/My/test.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include <avcall.h>
+
+int
+main(int argc, char *argv[])
+{
+  printf("version=%d.%d\n", LIBFFCALL_VERSION >> 8, LIBFFCALL_VERSION & 0xff);
+  return 0;
+}

--- a/lib/Alien/FFCall.pm
+++ b/lib/Alien/FFCall.pm
@@ -48,8 +48,6 @@ Your module (.pm) file should look like this:
  use strict;
  use warnings;
  
- use Alien::FFCall;
- 
  our $VERSION = '0.01';
  
  require XSLoader;


### PR DESCRIPTION
- subclass AB::ModuleBuild and implmenet alien_check_installed_version
  that probes for an existing ffcall
- requires AB 0.021 because alien_provides_libs was broken prior to
  that

This includes changes from #1 as a convenience since it would otherwise conflict.  If these commits can be merged and released to CPAN I can use this module for the FFI module.
