### PR TITLE
use AB::MB for configure requires

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -9,7 +9,7 @@ my $builder = My::ModuleBuild->new(
   dist_abstract => 'Build and install libffcall',
   license => 'perl',
   configure_requires => {
-    'Alien::Base' => 0.021,
+    'Alien::Base::ModuleBuild' => 0.021,
     'parent'      => 0,
   },
   requires => {


### PR DESCRIPTION
This will make sure `Alien::Build::ModuleBuild` is used as a configure_requires instead of `Alien::Base`.  For the rationale for this change, please see https://github.com/Perl5-Alien/Alien-Base/issues/157
